### PR TITLE
Use Less modules for build

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
+      submodules: true
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "micron"]
+	path = micron
+	url = https://github.com/webkul/micron

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
   "repository": "https://github.com/woofers/react-micron",
   "scripts": {
     "start": "yarn watch",
-    "build:css": "cp -r node_modules/webkul-micron/dist/css src/.",
-    "build:js": "cp -r node_modules/webkul-micron/build/script src/.",
+    "build:js": "cp -r micron/build/script src/.",
     "build:patch": "patch src/script/micron.js patches/micron.patch",
-    "build": "yarn clean && yarn build:css && yarn build:js && yarn build:patch && webpack",
-    "clean": "rimraf lib/react-micron.js lib/react-micron.dev.js src/css src/script",
+    "build": "yarn clean && yarn build:js && yarn build:patch && webpack",
+    "clean": "rimraf lib/react-micron.js lib/react-micron.dev.js src/script",
     "test": "echo \"No tests \" && exit 0"
   },
   "keywords": [
@@ -45,6 +44,7 @@
     "eslint": "^7.17.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-webpack-plugin": "^2.4.1",
+    "less-loader": "^7.2.1",
     "peer-deps-externals-webpack-plugin": "^1.0.4",
     "rimraf": "^3.0.2",
     "style-loader": "^2.0.0",

--- a/src/base.js
+++ b/src/base.js
@@ -1,5 +1,6 @@
 import React, { forwardRef, useRef, useEffect } from 'react'
 import micron from './script/micron'
+import global from '../micron/build/less/partials/_globals.less'
 
 const PropTypes = process.env.NODE_ENV !== 'production' ? require('prop-types') : {}
 
@@ -37,7 +38,7 @@ const Base = ({
   const ref = useRef()
   const events = encloseString(initialEvents)
   useEffect(() => {
-    const styles = encloseAll(initialStyles)
+    const styles = [global, ...(encloseAll(initialStyles))]
     styles.map(style => style.use())
     return () => {
       styles.map(style => style.unuse())

--- a/src/blink.js
+++ b/src/blink.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-blink.min.css'
+import styles from '../micron/build/less/partials/_blink.less'
 
 const Blink = p => <Base {...p} type="blink" styles={styles} />
 

--- a/src/bounce.js
+++ b/src/bounce.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-bounce.min.css'
+import styles from '../micron/build/less/partials/_bounce.less'
 
 const Bounce = p => <Base {...p} type="bounce" styles={styles} />
 

--- a/src/fade.js
+++ b/src/fade.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-fade.min.css'
+import styles from '../micron/build/less/partials/_fade.less'
 
 const Fade = p => <Base {...p} type="fade" styles={styles} />
 

--- a/src/flicker.js
+++ b/src/flicker.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-flicker.min.css'
+import styles from '../micron/build/less/partials/_flicker.less'
 
 const Flicker = p => <Base {...p} type="flicker" styles={styles} />
 

--- a/src/groove.js
+++ b/src/groove.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-groove.min.css'
+import styles from '../micron/build/less/partials/_groove.less'
 
 const Groove = p => <Base {...p} type="groove" styles={styles} />
 

--- a/src/jelly.js
+++ b/src/jelly.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-jelly.min.css'
+import styles from '../micron/build/less/partials/_jelly.less'
 
 const Jelly = p => <Base {...p} type="jelly" styles={styles} />
 

--- a/src/jerk.js
+++ b/src/jerk.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-jerk.min.css'
+import styles from '../micron/build/less/partials/_jerk.less'
 
 const Jerk = p => <Base {...p} type="jerk" styles={styles} />
 

--- a/src/pop.js
+++ b/src/pop.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-pop.min.css'
+import styles from '../micron/build/less/partials/_pop.less'
 
 const Pop = p => <Base {...p} type="pop" styles={styles} />
 

--- a/src/shake.js
+++ b/src/shake.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-shake.min.css'
+import styles from '../micron/build/less/partials/_shake.less'
 
 const Shake = p => <Base {...p} type="shake" styles={styles} />
 

--- a/src/squeeze.js
+++ b/src/squeeze.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-squeeze.min.css'
+import styles from '../micron/build/less/partials/_squeeze.less'
 
 const Squeeze = p => <Base {...p} type="squeeze" styles={styles} />
 

--- a/src/swing.js
+++ b/src/swing.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-swing.min.css'
+import styles from '../micron/build/less/partials/_swing.less'
 
 const Swing = p => <Base {...p} type="swing" styles={styles} />
 

--- a/src/tada.js
+++ b/src/tada.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Base, { propTypes, makeHoc } from './base'
-import styles from './css/micron-tada.min.css'
+import styles from '../micron/build/less/partials/_tada.less'
 
 const Tada = p => <Base {...p} type="tada" styles={styles} />
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,19 @@ const webpack = require('webpack')
 const ESLintPlugin = require('eslint-webpack-plugin');
 const { DefinePlugin } = webpack
 
+const css = (extra = []) => ([
+  {
+    loader: 'style-loader',
+    options: {
+      injectType: 'lazyStyleTag'
+    }
+  },
+  {
+    loader: 'css-loader'
+  },
+  ...extra
+])
+
 const config = mode => {
   const isDev = mode !== 'production'
   const name = `${json.name}${isDev ? '.dev' : ''}`
@@ -45,17 +58,11 @@ const config = mode => {
         },
         {
           test: /\.css$/,
-          use: [
-            {
-              loader: 'style-loader',
-              options: {
-                injectType: 'lazyStyleTag'
-              }
-            },
-            {
-              loader: 'css-loader'
-            }
-          ]
+          use: css()
+        },
+        {
+          test: /\.less$/,
+          use: css(['less-loader'])
         }
       ]
     }


### PR DESCRIPTION
This saves a bit of bundle space since the timing css classes
are not included multiple times.

This also allows the custom component to only include the timing css.